### PR TITLE
Update: Change default `contentcreator` scopes (fixes #38)

### DIFF
--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -46,8 +46,6 @@
 		      "displayName": "Content creator",
 		      "extends": "authuser",
 		      "scopes": [
-		        "export:adapt",
-		        "import:adapt",
 		        "preview:adapt",
 		        "publish:adapt",
 		        "read:assets",


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
Fixes #38

[//]: # (Delete as appropriate)
### Update
* Removed 'export:adapt' and 'import:adapt' from scopes
