### PR TITLE
Fix: enable cache after role initialisation (fixes #44)

### DIFF
--- a/lib/RolesModule.js
+++ b/lib/RolesModule.js
@@ -8,7 +8,6 @@ class RolesModule extends AbstractApiModule {
   /** @override */
   async init () {
     await super.init()
-    this.cache.isEnabled = true
     try {
       await this.initConfigRoles()
 
@@ -17,6 +16,7 @@ class RolesModule extends AbstractApiModule {
     } catch (e) {
       this.log('error', e)
     }
+    this.cache.isEnabled = true
     const [authlocal, users] = await this.app.waitForModule('auth-local', 'users')
     authlocal.registerHook.tap(this.onUpdateRoles.bind(this))
     users.requestHook.tap(this.onUpdateRoles.bind(this))


### PR DESCRIPTION
### Fix
* Move `this.cache.isEnabled = true` to after the `initConfigRoles()` / `initDefaultRoles()` try/catch block to prevent stale or empty cached results during startup

### Testing
1. Start the authoring tool and verify roles are correctly loaded
2. Confirm cached role lookups return expected data

🤖 Generated with [Claude Code](https://claude.com/claude-code)