### PR TITLE
New: Declare Roles input type on the user roles property

### DIFF
--- a/schema/userroles.schema.json
+++ b/schema/userroles.schema.json
@@ -7,13 +7,17 @@
     "with": {
       "properties": {
         "roles": {
+          "title": "Role",
           "description": "Roles assigned to this user",
           "type": "array",
           "items": {
             "type": "string",
             "isObjectId": true
           },
-          "default": []
+          "default": [],
+          "_adapt": {
+            "inputType": "Roles"
+          }
         }
       }
     }


### PR DESCRIPTION
### New
* The `roles` property added to the user schema now declares `_adapt.inputType: "Roles"` (plus a singular `"Role"` title), so the authoring UI auto-maps the field to a role-picker widget rather than rendering a raw objectId array input.

This keeps the widget choice owned by the module that owns the field, mirroring how `userGroups` declares `inputType: "UserGroups"`. The matching widget is registered UI-side in adapt-authoring-ui.

### Testing
1. Open a user in the authoring tool's user edit panel.
2. Confirm the role field renders as a dropdown of role display names (not an editable objectId list).