### PR TITLE
Chore: drop vestigial disavow:auth/clear:session scopes (fixes #54)

### DIFF
--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -33,12 +33,10 @@
 		      "shortName": "authuser",
 		      "displayName": "Authenticated user",
 		      "scopes": [
-		        "clear:session",
 		        "read:config",
 		        "read:lang",
 		        "read:me",
-		        "write:me",
-		        "disavow:auth"
+		        "write:me"
 		      ]
 		    },
 		    {


### PR DESCRIPTION
### Fixes #54

### Chore

- Removed `disavow:auth` and `clear:session` from the default `authuser` role in `conf/config.schema.json`. Neither scope gates anything: `POST /api/auth/disavow` is being made authenticated-only (logout is self-authorising), and `/api/session/clear` has no registered handler. Only affects freshly-seeded installs; existing DB roles keep the (harmless, unused) scopes.
